### PR TITLE
Do not print the full help for unknown commands

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,10 +75,11 @@ export default async function cli(args) {
     }
 
     await command.command(reindex, params);
+  } else if (commandName) {
+    process.stdout.write(chalk.red(
+      `'${commandName}' is not a Reindex command. See 'reindex help'. \n`
+    ));
   } else {
-    if (commandName) {
-      process.stdout.write(chalk.red(`Unknown command ${commandName}\n`));
-    }
     printCommands();
   }
 }


### PR DESCRIPTION
This makes it easier to find the actual error from the output.
E.g.

```
> reindex schema-psuh
'schema-psuh' is not a Reindex command. See 'reindex help'.
```
