### PR TITLE
Improve error handling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "react/jsx-quotes": 0,
     "block-scoped-var": 0,
     "comma-dangle": [2, "always-multiline"],
+    "no-console": 0,
     "no-else-return": 0,
     "no-unused-vars": [2, {"vars": "all", "args": "none"}],
     "no-use-before-define": 0,

--- a/bin/reindex
+++ b/bin/reindex
@@ -6,5 +6,5 @@ cli(process.argv.slice(2))
   .then(function () {
     process.exit(0);
   }, function (error) {
-    process.stderr.write(error.toString() + '\n');
+    console.error(error);
   });

--- a/src/commands/schemaFetch.js
+++ b/src/commands/schemaFetch.js
@@ -48,24 +48,27 @@ async function fetchSchema(reindex, passedTarget) {
     throw new Error(chalk.red(`File ${target} already exists.`));
   }
 
-  process.stdout.write(`Fetching Reindex schema from ${reindex._url}...\n`);
-  const response = await reindex.query(SCHEMA_QUERY);
-  const result = await response.json();
-  if (result.errors) {
-    process.stderr.write(JSON.stringify(result.errors, null, 2));
-    process.stderr.write('\n');
-  } else {
-    const types = result.data.viewer.allReindexTypes.nodes;
-    const processed = types.map((type) => {
-      const cleanType = omit(type, (value) => value === null);
-      cleanType.fields = cleanType.fields.map(
-        (field) => omit(field, (value) => value === null)
-      );
-      return cleanType;
-    });
-    process.stdout.write(`Writing to ${target}...\n`);
-    fs.writeFileSync(target, JSON.stringify(processed, null, 2) + '\n');
-    process.stdout.write('Done!\n');
+  try {
+    process.stdout.write(`Fetching Reindex schema from ${reindex._url}...\n`);
+    const result = await reindex.query(SCHEMA_QUERY);
+    if (result.errors) {
+      process.stderr.write(JSON.stringify(result.errors, null, 2));
+      process.stderr.write('\n');
+    } else {
+      const types = result.data.viewer.allReindexTypes.nodes;
+      const processed = types.map((type) => {
+        const cleanType = omit(type, (value) => value === null);
+        cleanType.fields = cleanType.fields.map(
+          (field) => omit(field, (value) => value === null)
+        );
+        return cleanType;
+      });
+      process.stdout.write(`Writing to ${target}...\n`);
+      fs.writeFileSync(target, JSON.stringify(processed, null, 2) + '\n');
+      process.stdout.write('Done!\n');
+    }
+  } catch (e) {
+    throw e;
   }
 }
 

--- a/src/commands/schemaPush.js
+++ b/src/commands/schemaPush.js
@@ -25,14 +25,13 @@ async function pushSchema(reindex, passedTarget, { dryRun, force }) {
     process.stdout.write(`Reading schema from ${target}...\n`);
     const schema = JSON.parse(fs.readFileSync(target));
     process.stdout.write(`Requesting migration from API...\n`);
-    const response = await reindex.query(MIGRATE_QUERY, {
+    const result = await reindex.query(MIGRATE_QUERY, {
       input: {
         dryRun,
         force,
         types: schema,
       },
     });
-    const result = await response.json();
     if (result.errors) {
       process.stderr.write(chalk.yellow('\nValidation errors:\n\n'));
       let errors = result.errors;

--- a/src/commands/schemaRelay.js
+++ b/src/commands/schemaRelay.js
@@ -9,17 +9,15 @@ async function fetchRelaySchema(reindex, target) {
     throw new Error(chalk.red('Please specify file to save schema to.'));
   }
   process.stdout.write(`Fetching Relay schema from ${reindex._url}...\n`);
-  const response = await reindex.query(introspectionQuery);
-  const result = await response.json();
-  if (response.status < 200 || response.status >= 300) {
-    throw new Error(
-      `Fetching the schema from '${reindex._url}' failed. ${result.error || ''}`
-    );
+  try {
+    const result = await reindex.query(introspectionQuery);
+    const jsonResult = JSON.stringify(result, null, 2);
+    process.stdout.write(`Writing to ${target}...\n`);
+    fs.writeFileSync(target, jsonResult);
+    process.stdout.write('Done!\n');
+  } catch (e) {
+    throw e;
   }
-  const jsonResult = JSON.stringify(result, null, 2);
-  process.stdout.write(`Writing to ${target}...\n`);
-  fs.writeFileSync(target, jsonResult);
-  process.stdout.write('Done!\n');
 }
 
 export default function schemaRelay(reindex, args) {


### PR DESCRIPTION
Catch HTTP errors in all commands.

Depends on https://github.com/reindexio/reindex-js/pull/1,
which moves JSON parsing to the library and adds better errors.
