### PR TITLE
Fetch all types in the schema

### DIFF
--- a/src/commands/schemaFetch.js
+++ b/src/commands/schemaFetch.js
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 const SCHEMA_QUERY = `
   query schemaQuery {
     viewer {
-      allReindexTypes {
+      allReindexTypes(first: 2147483647) {
         nodes {
           name,
           kind,


### PR DESCRIPTION
Previously `schema-fetch` used `allReindexTypes` without any arguments
and only fetched the first 10 types, resulting in an incomplete schema.

Specify the maximum 32-bit signed integer as the `first` argument,
should be enough for any reasonable schema.
